### PR TITLE
new release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ioredis-encrypted",
   "description": "A wrapper for ioredis that encrypts and decrypts data stored.",
-  "version": "2.0.0",
+  "version": "2.0.1,
   "homepage": "https://github.com/Stono/ioredis-encrypted",
   "author": {
     "name": "Karl Stoney",


### PR DESCRIPTION
Why is the release version history not visible?
https://github.com/Stono/ioredis-encrypted/releases